### PR TITLE
Fix empty $route (error routes) in YAML DB

### DIFF
--- a/count-views.php
+++ b/count-views.php
@@ -58,6 +58,7 @@ class CountViewsPlugin extends Plugin
         // Get page route
         $page = $this->grav['page'];
         $route = $page->route();
+        if (empty($route)) $route = $this->config->get('plugins.error.routes.404', '/error');
 
         // Open data file
         $datafh = File::instance($path);
@@ -83,6 +84,7 @@ class CountViewsPlugin extends Plugin
         // Get page route
         $page = $this->grav['page'];
         $route = $page->route();
+        if (empty($route)) $route = $this->config->get('plugins.error.routes.404', '/error');
 
         // Open data file
         $datafh = File::instance($path);


### PR DESCRIPTION
This fixes the problem where error routes end up in the YAML DB as `'': 1`. Uses the 404 route setting for the _error_ plugin, or `/error` as fallback.